### PR TITLE
Update Go Version to 1.20 for IBC-Apps Compatibility

### DIFF
--- a/nodes-and-validators/run-a-node/build-the-xion-daemon.md
+++ b/nodes-and-validators/run-a-node/build-the-xion-daemon.md
@@ -19,7 +19,7 @@ Adequate installation and configuration of your environment is out of scope. Ple
 {% hint style="info" %}
 :warning: **Go Versions**
 
-We use Go version 1.19 internally at Burnt.
+We use Go version 1.20 internally at Burnt.
 
 If you are building the binary yourself, please make sure you are using Go 1.19, as we have observed consensus-breaking behavior on nodes that are not running the same version as the majority of the network.\
 A specific symptom of this would be an `AppHash` mismatch.


### PR DESCRIPTION
This PR updates the Go version requirement from 1.19  to 1.20 for the Xion project. The update is necessary to resolve a build error encountered when compiling the `packet-forward-middleware` module, which requires Go 1.20 due to its reliance on the `errors.Join` function introduced in this version.

**Error Encountered:**
```
# github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/packetforward/keeper
../go/pkg/mod/github.com/burnt-labs/ibc-apps/middleware/packet-forward-middleware/v7@v7.1.3-0.20240308232808-736bd51c54ad/packetforward/keeper/keeper.go:172:73: undefined: errors.Join
note: module requires Go 1.20
make: *** [Makefile:94: install] Error 2
```
**Changes Made:**
- Updated documentation in `docs/build-the-xion-daemon.md` to reflect the new Go version requirement.
- Updated all relevant configuration files and scripts to use Go 1.20.

This change ensures compatibility with batch-forwarding software and any future dependencies requiring newer Go features.