### PR TITLE
Base Directory Update

### DIFF
--- a/nodes-and-validators/run-a-node/configure-the-xion-daemon/README.md
+++ b/nodes-and-validators/run-a-node/configure-the-xion-daemon/README.md
@@ -18,17 +18,17 @@ The [Cosmos SDK documentation](https://docs.cosmos.network/v0.47) is a good plac
 
 ## Initialize the Xion Daemon
 
-* As is the case for most Cosmos-based chains, the daemon is initialized like so:
+- As is the case for most Cosmos-based chains, the daemon is initialized like so:
 
 ```
 $ xiond init my-awesome-moniker \
     --chain-id xion-testnet-1 \
-    --home /tmp/node
+    --home /root/.xiond/
 ```
 
 ## Refer to the config directory
 
-* The `xiond init` command will output this structure to the specified `--home:`
+- The `xiond init` command will output this structure to the specified `--home:`
 
 ```
 .                                   # /tmp/node
@@ -52,4 +52,3 @@ However, if the purpose of your node is persistent, such as running a Validator,
 {% endhint %}
 
 <table data-view="cards"><thead><tr><th></th><th align="center"></th><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td></td><td align="center"><code>app.toml</code></td><td></td><td><a href="app.toml.md">app.toml.md</a></td></tr><tr><td></td><td align="center"><code>client.toml</code></td><td></td><td><a href="client.toml.md">client.toml.md</a></td></tr><tr><td></td><td align="center"><code>config.toml</code></td><td></td><td><a href="config.toml.md">config.toml.md</a></td></tr></tbody></table>
-

--- a/nodes-and-validators/run-a-node/configure-the-xion-daemon/config.toml.md
+++ b/nodes-and-validators/run-a-node/configure-the-xion-daemon/config.toml.md
@@ -38,7 +38,7 @@ moniker = "copypaste.com"
 # allows them to catchup quickly by downloading blocks in parallel
 # and verifying their commits
 #
-# Deprecated: this key will be removed and BlockSync will be enabled 
+# Deprecated: this key will be removed and BlockSync will be enabled
 # unconditionally in the next major release.
 block_sync = true
 
@@ -229,7 +229,7 @@ laddr = "tcp://0.0.0.0:26656"
 external_address = ""
 
 # Comma separated list of seed nodes to connect to
-seeds = ""
+seeds = "7900d5f177228def24170f9631db76afab20278e@seed.xion-testnet-1.burnt.com:11656"
 
 # Comma separated list of nodes to keep persistent connections to
 persistent_peers = ""
@@ -384,7 +384,7 @@ chunk_fetchers = "4"
 [blocksync]
 
 # Block Sync version to use:
-# 
+#
 # In v0.37, v1 and v2 of the block sync protocols were deprecated.
 # Please use v0 instead.
 #

--- a/nodes-and-validators/run-a-node/download-the-xion-daemon.md
+++ b/nodes-and-validators/run-a-node/download-the-xion-daemon.md
@@ -20,28 +20,25 @@ Adequate installation and configuration of your environment is out of scope. Ple
 
 ## Download the image from Docker Hub
 
-* We publish Docker images to Docker Hub on every commit to `main`.
-* The image versions are tagged with the short Git SHA.
-* We do not use the `latest` tag, to avoid confusion and mistakes.
+- We publish Docker images to Docker Hub on every commit to `main`.
+- The image versions are tagged with the short Git SHA.
+- We do not use the `latest` tag, to avoid confusion and mistakes.
 
 ```
-$ docker pull burntnetwork/xion:latest
+$ docker pull burntnetwork/xion:sha-34c82a9
 ```
 
 {% hint style="info" %}
 For more up to date tags checkout the docker hub page for this image [here](https://hub.docker.com/r/burntnetwork/xion/tags)
 {% endhint %}
 
-
-
 ## Obtain a shell in the Docker container
 
-* We can now invoke the `xiond` binary inside the container.
+- We can now invoke the `xiond` binary inside the container.
 
 ```
-$ docker run -ti burntnetwork/xion:latest /bin/bash
+$ docker run -ti burntnetwork/xion:sha-34c82a9 /bin/bash
 # xiond version
 # xiond version --long
 # xiond --help
 ```
-

--- a/nodes-and-validators/run-a-node/join-the-xion-network/README.md
+++ b/nodes-and-validators/run-a-node/join-the-xion-network/README.md
@@ -13,8 +13,8 @@ With a configured Xion Daemon, we can attempt to join one of the Xion Networks.
 | `xion-testnet-1` | [genesis.json](https://files.xion-testnet-1.burnt.com/genesis.json) | [addrbook.json](https://files.xion-testnet-1.burnt.com/addrbook.json) | [latest.tar.lz4](https://files.xion-testnet-1.burnt.com/xion-testnet-1-latest.tar.lz4) |
 | `xion-mainnet-1` | TBD                                                                 | TBD                                                                   | TBD                                                                                    |
 
-* The Genesis JSON file specifies the account balances and parameters at the inception of the network, and anchors the application state to a point in time.
-* The Addressbook lists a selection of peers for your node to dial, such that it may discover other nodes in the network.&#x20;
+- The Genesis JSON file specifies the account balances and parameters at the inception of the network, and anchors the application state to a point in time.
+- The Addressbook lists a selection of peers for your node to dial, such that it may discover other nodes in the network.&#x20;
 
 ## Configure the Network information
 
@@ -27,6 +27,5 @@ For detailed information on how to join each network, please refer to its corres
 Finally, with all the configurations in place, we can start synchronizing our node:
 
 ```
-$ xiond start --x-crisis-skip-invariants --home /home/xiond/.xiond
+xiond start  --home /root/.xiond
 ```
-

--- a/nodes-and-validators/run-a-node/join-the-xion-network/xion-testnet-1.md
+++ b/nodes-and-validators/run-a-node/join-the-xion-network/xion-testnet-1.md
@@ -6,8 +6,6 @@ description: Details to join the xion-testnet-1 network.
 
 ## Upgrade Path
 
-
-
 | Git Tag  | Docker Tag    | Git SHA                                    | Block Height | Requires Halt |
 | -------- | ------------- | ------------------------------------------ | ------------ | ------------- |
 | `v0.1.0` | `sha-2722f0f` | `2722f0fb1234db97e9bf9b98f744675eb8fb1b26` | `0`          | `false`       |
@@ -21,15 +19,14 @@ description: Details to join the xion-testnet-1 network.
 
 The different Hosts and Endpoints of `xion-testnet-1` are:
 
-*   **Seeds**
+- **Seeds**
 
-    * `eb029462c82b46d842a47122d860617bff627fdf@xion-testnet-1.burnt.com:11656`
+  - `eb029462c82b46d842a47122d860617bff627fdf@xion-testnet-1.burnt.com:11656`
 
-
-* **Peers**
-  * `6bb70718db6af0a473c9d76e82d9ade33618b20d@xion-testnet-1.burnt.com:32656`
-  * `0f2ccb6d7e8f233c03f91dee690f5ff714319fba@xion-testnet-1.burnt.com:33656`
-  * `f684e3873191d62a74e5431202581d99fe3439b7@xion-testnet-1.burnt.com:34656`
+- **Peers**
+  - `6bb70718db6af0a473c9d76e82d9ade33618b20d@xion-testnet-1.burnt.com:32656`
+  - `0f2ccb6d7e8f233c03f91dee690f5ff714319fba@xion-testnet-1.burnt.com:33656`
+  - `f684e3873191d62a74e5431202581d99fe3439b7@xion-testnet-1.burnt.com:34656`
 
 ## Download the Genesis JSON file
 
@@ -39,7 +36,7 @@ We provide a sample snippet which will download the `genesis.json` to the correc
 #!/usr/bin/env bash
 set -euxo pipefail
 
-BASEDIR="/home/xiond/.xiond"
+BASEDIR="/root/.xiond/"
 GENESIS_JSON="https://files.xion-testnet-1.burnt.com/genesis.json"
 
 curl ${GENESIS_JSON} -o ${BASEDIR}/config/genesis.json -s
@@ -66,7 +63,7 @@ You may also want to download a fresh `addrbook.json` to help with peer discover
 #!/usr/bin/env bash
 set -euxo pipefail
 
-BASEDIR="/home/xiond/.xiond"
+BASEDIR="/root/.xiond/"
 ADDRBOOK_JSON="https://files.xion-testnet-1.burnt.com/addrbook.json"
 
 curl ${ADDRBOOK_JSON} -o ${BASEDIR}/config/addrbook.json -s
@@ -92,7 +89,7 @@ We provide a sample snippet, with which to download our latest public snapshot.
 #!/usr/bin/env bash
 set -euxo pipefail
 
-BASEDIR="/home/xiond/.xiond"
+BASEDIR="/root/.xiond/"
 TAR_LZ4="https://files.xion-testnet-1.burnt.com/xion-testnet-1-latest.tar.lz4"
 
 curl -o - -L ${TAR_LZ4} | lz4 -c -d - | tar -x -v -C ${BASEDIR}
@@ -118,7 +115,7 @@ TRUST_HASH=$(curl -s "$SNAP_RPC/block?height=$BLOCK_HEIGHT" | jq -r .result.bloc
 sed -i.bak -E "s|^(enable[[:space:]]+=[[:space:]]+).*$|\1true| ; \
 s|^(rpc_servers[[:space:]]+=[[:space:]]+).*$|\1\"$SNAP_RPC,$SNAP_RPC\"| ; \
 s|^(trust_height[[:space:]]+=[[:space:]]+).*$|\1$BLOCK_HEIGHT| ; \
-s|^(trust_hash[[:space:]]+=[[:space:]]+).*$|\1\"$TRUST_HASH\"|" $HOME/.burnt/config/config.toml
+s|^(trust_hash[[:space:]]+=[[:space:]]+).*$|\1\"$TRUST_HASH\"|" /root/.xiond/config/config.toml
 ```
 
 {% hint style="info" %}
@@ -130,4 +127,3 @@ If State Sync just isn't working for you, **DON'T PANIC!**
 
 Try the restore using a Node snapshot instead.
 {% endhint %}
-


### PR DESCRIPTION
This pull request addresses an issue with the base directory path specified in the documentation. 

### Changes Made
- Updated the base directory path in the [specific file or section where the change was made].
 -Updated  docker image tag
### Rationale
The previous path led to confusion and potential errors for users setting up [/home/xiond/.xiond/]. This update ensures that the documentation matches the actual directory structure expected by the project, thereby improving usability and reducing setup errors.


- Please let me know if there are any further changes or additions needed.
