### PR TITLE
docs(computation): Rust 1.86 toolchain note for WASM store on XION

### DIFF
--- a/developers/computation/README.md
+++ b/developers/computation/README.md
@@ -10,13 +10,15 @@ The Computation Layer covers smart contracts (automations), business logic, and 
 
 WASM binaries built with the **latest stable Rust** may fail to upload to XION (`xiond tx wasm store`) because the chain does not support WebAssembly **bulk memory** instructions that newer Rust toolchains can emit.
 
-If you run into store or validation errors after upgrading Rust, pin the toolchain in your **contract project root** with a `rust-toolchain.toml` file:
+If you run into store or validation errors after upgrading Rust, create `rust-toolchain.toml` at your **contract project root**:
 
 ```toml
 [toolchain]
 channel = "1.86"
 targets = ["wasm32-unknown-unknown"]
 ```
+
+**Why 1.86?** Rust **1.87+** stable releases may emit WebAssembly with **bulk memory** enabled for `wasm32-unknown-unknown`. XION’s `wasm store` and runtime do not support bulk memory today, so uploads can fail even when local builds succeed. **1.86** is the latest stable release known to produce upload-compatible WASM for XION at the time of writing (May 2026). When you upgrade Rust—or when XION enables bulk memory—re-test `xiond tx wasm store` and update the pinned channel if needed.
 
 Rebuild the contract (and re-run the [CosmWasm optimizer](local-development/deploy-a-cosmwasm-smart-contract.md) if you use Docker) before uploading again. See also the [local environment setup](local-development/setting-up-env/installation-prerequisites-setup-local-environment.md#rust) guide.
 

--- a/developers/computation/README.md
+++ b/developers/computation/README.md
@@ -6,6 +6,20 @@ icon: user-robot
 
 The Computation Layer covers smart contracts (automations), business logic, and workflows on XION.
 
+### Contract development notes
+
+WASM binaries built with the **latest stable Rust** may fail to upload to XION (`xiond tx wasm store`) because the chain does not support WebAssembly **bulk memory** instructions that newer Rust toolchains can emit.
+
+If you run into store or validation errors after upgrading Rust, pin the toolchain in your **contract project root** with a `rust-toolchain.toml` file:
+
+```toml
+[toolchain]
+channel = "1.86"
+targets = ["wasm32-unknown-unknown"]
+```
+
+Rebuild the contract (and re-run the [CosmWasm optimizer](local-development/deploy-a-cosmwasm-smart-contract.md) if you use Docker) before uploading again. See also the [local environment setup](local-development/setting-up-env/installation-prerequisites-setup-local-environment.md#rust) guide.
+
 ### Overview
 
 Smart contracts on XION are built using CosmWasm and enable:

--- a/developers/computation/local-development/deploy-a-cosmwasm-smart-contract.md
+++ b/developers/computation/local-development/deploy-a-cosmwasm-smart-contract.md
@@ -66,7 +66,7 @@ If you’re deploying contracts on **XION Mainnet**, you can acquire XION tokens
 ## **Compile and Optimize the Contract**
 
 {% hint style="warning" %}
-WASM built with the **latest stable Rust** may fail to **store** on XION because bulk memory is not supported. If upload fails after a Rust upgrade, add `rust-toolchain.toml` in the contract project root:
+WASM built with the **latest stable Rust** may fail to **store** on XION because bulk memory is not supported. If upload fails after a Rust upgrade, create `rust-toolchain.toml` at the contract project root and pin **1.86** (latest stable known to avoid bulk memory for `wasm32-unknown-unknown` as of May 2026; re-test when upgrading Rust or when XION enables bulk memory):
 
 ```toml
 [toolchain]

--- a/developers/computation/local-development/deploy-a-cosmwasm-smart-contract.md
+++ b/developers/computation/local-development/deploy-a-cosmwasm-smart-contract.md
@@ -65,6 +65,18 @@ If you’re deploying contracts on **XION Mainnet**, you can acquire XION tokens
 
 ## **Compile and Optimize the Contract**
 
+{% hint style="warning" %}
+WASM built with the **latest stable Rust** may fail to **store** on XION because bulk memory is not supported. If upload fails after a Rust upgrade, add `rust-toolchain.toml` in the contract project root:
+
+```toml
+[toolchain]
+channel = "1.86"
+targets = ["wasm32-unknown-unknown"]
+```
+
+Then rebuild and re-run the optimizer below before `xiond tx wasm store`.
+{% endhint %}
+
 To demonstrate the deployment process, we’ll use a simple [**Counter**](https://github.com/burnt-labs/cw-counter) smart contract. This contract provides an example of state management on the XION blockchain. It allows you to:
 
 * Set an initial counter value

--- a/developers/computation/local-development/setting-up-env/installation-prerequisites-setup-local-environment.md
+++ b/developers/computation/local-development/setting-up-env/installation-prerequisites-setup-local-environment.md
@@ -84,16 +84,18 @@ After installation, verify **Rust** is correctly installed:
 rustc --version
 ```
 
-You should see output similar to the following::
+You should see output similar to the following (your exact version may differ):
 
 ```
-rustc 1.82.0-nightly (c1a6199e9 2024-07-24)
+rustc 1.86.0
 ```
+
+Your global Rust install does not need to match **1.86** exactly, but each **contract repo** should pin **1.86** for WASM builds that upload to XION (see below).
 
 ### Pin the Rust toolchain for XION
 
 {% hint style="warning" %}
-WASM built with the **latest stable Rust** may fail to upload to XION because the chain does not support WebAssembly **bulk memory**. If `xiond tx wasm store` or validation fails after a Rust upgrade, add `rust-toolchain.toml` in your **contract project root** (not only in your global Rust install):
+WASM built with the **latest stable Rust** may fail to upload to XION because the chain does not support WebAssembly **bulk memory**. If `xiond tx wasm store` or validation fails after a Rust upgrade, create `rust-toolchain.toml` at your **contract project root** (not only in your global Rust install):
 {% endhint %}
 
 ```toml
@@ -101,6 +103,8 @@ WASM built with the **latest stable Rust** may fail to upload to XION because th
 channel = "1.86"
 targets = ["wasm32-unknown-unknown"]
 ```
+
+**Why 1.86?** Rust **1.87+** may enable bulk memory for `wasm32-unknown-unknown`, which XION rejects today. **1.86** is the latest stable release known to produce upload-compatible WASM for XION at the time of writing (May 2026). Re-test uploads and update this pin when you upgrade Rust or when XION adds bulk memory support.
 
 Commit this file with your contract repo so CI and teammates use the same toolchain, then rebuild before deploying.
 
@@ -116,10 +120,10 @@ Run the following command to check if Cargo is already installed:
 cargo --version
 ```
 
-If Cargo is installed, you should see an output similar to:
+If Cargo is installed, you should see an output similar to (your exact version may differ):
 
 ```
-cargo 1.82.0-nightly (5f6b9a922 2024-07-19)
+cargo 1.86.0
 ```
 
 If Cargo is missing, follow the installation steps below.

--- a/developers/computation/local-development/setting-up-env/installation-prerequisites-setup-local-environment.md
+++ b/developers/computation/local-development/setting-up-env/installation-prerequisites-setup-local-environment.md
@@ -90,6 +90,20 @@ You should see output similar to the following::
 rustc 1.82.0-nightly (c1a6199e9 2024-07-24)
 ```
 
+### Pin the Rust toolchain for XION
+
+{% hint style="warning" %}
+WASM built with the **latest stable Rust** may fail to upload to XION because the chain does not support WebAssembly **bulk memory**. If `xiond tx wasm store` or validation fails after a Rust upgrade, add `rust-toolchain.toml` in your **contract project root** (not only in your global Rust install):
+{% endhint %}
+
+```toml
+[toolchain]
+channel = "1.86"
+targets = ["wasm32-unknown-unknown"]
+```
+
+Commit this file with your contract repo so CI and teammates use the same toolchain, then rebuild before deploying.
+
 ## Cargo
 
 Cargo is Rust's package manager and build system, essential for compiling and managing dependencies in XION smart contract development. When installing Rust using **rustup** which we did earlier, Cargo is automatically included. However, if Cargo is missing or needs to be installed separately, follow the steps below.


### PR DESCRIPTION
## Summary

- Document that WASM built with the latest stable Rust may fail to upload to XION because bulk memory is not supported.
- Add `rust-toolchain.toml` guidance (`channel = "1.86"`, `wasm32-unknown-unknown`) in the computation overview, local env setup (Rust section), and first contract deploy guide.

## Test plan

- [ ] Preview GitBook / docs render for the three updated pages
- [ ] Confirm `rust-toolchain.toml` snippet matches team recommendation
- [ ] Verify internal links in `developers/computation/README.md` resolve correctly


Made with [Cursor](https://cursor.com)